### PR TITLE
ci: read cloudflare credentials from action input

### DIFF
--- a/.github/cloudflare-deploy.sh
+++ b/.github/cloudflare-deploy.sh
@@ -13,8 +13,6 @@ echo "Checking if project exists..."
 
 # Specifically scoped for public contributors to automatically deploy to our team Cloudflare account
 
-CLOUDFLARE_ACCOUNT_ID="17b9dfa79e16b79dffcb11a66768539c"
-
 # Fetch the list of projects and check if the specific project exists
 project_exists=$(curl -s -X GET "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,12 @@ inputs:
   pull_request_number:
     description: "Pull request number for posting the deployment link"
     required: true
+  cloudflare_account_id:
+    description: "Cloudflare account id"
+    required: true
+  cloudflare_api_token:
+    description: "Cloudflare API token"
+    required: true
   commit_sha:
     description: "Commit SHA for posting the deployment link"
     required: false
@@ -39,7 +45,8 @@ runs:
       run: bash ../../_actions/ubiquity/cloudflare-deploy-action/main/.github/cloudflare-deploy.sh "${{ inputs.repository }}" "${{ inputs.production_branch }}" "${{ inputs.output_directory }}" "${{ inputs.current_branch }}"
       shell: bash
       env:
-        CLOUDFLARE_API_TOKEN: "JWo5dPsoyohH5PRu89-RktjCvRN0-ODC6CC9ZBqF"
+        CLOUDFLARE_ACCOUNT_ID: ${{ inputs.cloudflare_account_id }}
+        CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare_api_token }}
 
     - name: Post Deployment on Pull Request or Commit
       shell: bash


### PR DESCRIPTION
Resolves https://github.com/ubiquity/cloudflare-deploy-action/issues/1

We can't read organization secrets from composite actions ([related stackoverflow question](https://stackoverflow.com/questions/70098241/using-secrets-in-composite-actions-github)). 

This PR updates cloudflare deploy action to receive cloudflare account id and API token from action inputs.

So the flow is this one:
1. On a new PR [init](https://github.com/ubiquity/ts-template/blob/development/.github/workflows/init.yml) is called
2. After init the [build](https://github.com/ubiquity/ts-template/blob/development/.github/workflows/build.yml) is called (which has access to organization secrets)
3. Build calls cloudflare deploy action and [passes](https://github.com/ubiquity/test-cf-deploy/blob/7de57731874b53345e58675899d285f301cbecd6/.github/workflows/build.yml#L47-L48) cloudflare credentials