### PR TITLE
fix: prevent deploy to production on open PR

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,11 +50,13 @@ runs:
           const items = response.data.items
           if (items.length < 1) {
             console.error('No PRs found')
-            return
+            return {forcePreviewDeploy: false, pullRequestNumber: null }
           }
           const pullRequestNumber = items[0].number
+          const forcePreviewDeploy = pullRequestNumber > 0  && items[0].pull_request.merged_at == null
           console.info("Pull request number is", pullRequestNumber)
-          return pullRequestNumber
+          console.info("forcePreviewDeploy", forcePreviewDeploy)
+          return {forcePreviewDeploy: forcePreviewDeploy, pullRequestNumber: pullRequestNumber }
 
     - name: Download build artifact
       uses: dawidd6/action-download-artifact@v3
@@ -64,7 +66,7 @@ runs:
         run_id: ${{ inputs.workflow_run_id }}
 
     - name: Deploy to Cloudflare
-      run: bash ../../_actions/ubiquity/cloudflare-deploy-action/main/.github/cloudflare-deploy.sh "${{ inputs.repository }}" "${{ inputs.production_branch }}" "${{ inputs.output_directory }}" "${{ inputs.current_branch }}"
+      run: bash ../../_actions/ubiquity/cloudflare-deploy-action/main/.github/cloudflare-deploy.sh "${{ inputs.repository }}" "${{ inputs.production_branch }}" "${{ inputs.output_directory }}" "${{ fromJSON(steps.pr.outputs.result).forcePreviewDeploy && format('{0}/{1}', github.repository_owner, inputs.current_branch) || inputs.current_branch }}"
       shell: bash
       env:
         CLOUDFLARE_ACCOUNT_ID: ${{ inputs.cloudflare_account_id }}
@@ -78,5 +80,5 @@ runs:
         yarn tsx src/index.ts \
         --deployment_output "${{ env.DEPLOYMENT_OUTPUT }}" \
         --repository "${{ inputs.repository }}" \
-        --pull_request_number "${{ steps.pr.outputs.result }}" \
+        --pull_request_number "${{ fromJSON(steps.pr.outputs.result).pullRequestNumber }}" \
         --commit_sha "${{ inputs.commit_sha }}"


### PR DESCRIPTION
Resolves https://github.com/ubiquity/cloudflare-deploy-action/issues/8

## QA

It does not affect the normal operations of a fork. A fork's change on the `development` branch (or whatever the default branch is) gets deployed to production. All other branches get deployed to preview. 
Action: https://github.com/EresDevOrg/3rd-fork-pay.ubq.fi/actions/runs/8526016642/job/23355077672
![image](https://github.com/EresDevOrg/pay.ubq.fi/assets/11886219/3209603a-7384-4ab8-a258-fd084ab8f4e6)


When a fork opens a pull request to the ubiquity's `development` branch, it gets deployed to Cloudflare preview. 
Action: https://github.com/EresDevOrg/pay.ubq.fi/actions/runs/8526313017/job/23355279324
PR: https://github.com/EresDevOrg/pay.ubq.fi/pull/14
![image](https://github.com/EresDevOrg/pay.ubq.fi/assets/11886219/d0094395-2977-41eb-a9c9-dc976cb66821)


When the pull request is merged, it gets deployed to the production. 
Action: https://github.com/EresDevOrg/pay.ubq.fi/actions/runs/8526347581/job/23355387087
PR: https://github.com/EresDevOrg/pay.ubq.fi/pull/14
![image](https://github.com/EresDevOrg/pay.ubq.fi/assets/11886219/8af1808d-74b0-4766-9b51-777fc1fff49a)






<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
