### PR TITLE
Ci/fix multiple deploy urls

### DIFF
--- a/.github/cloudflare-deploy.sh
+++ b/.github/cloudflare-deploy.sh
@@ -44,13 +44,6 @@ yarn add wrangler --ignore-scripts
 output=$(yarn wrangler pages deploy "$STATICS_DIRECTORY" --project-name "$REPOSITORY_NAME" --branch "$CURRENT_BRANCH" --commit-dirty=true)
 output="${output//$'\n'/ }"
 # Extracting URL from output only
-url=$(echo "$output" | grep -o 'https://[^ ]*' | sed 's/ //g')
-
-# debug
-echo "===output==="
-echo $output
-echo "===url==="
-echo $url
-
+url=$(echo "$output" | grep -o 'https://[^ ]*' | sed 's/ //g' | head -n 1)
 echo "DEPLOYMENT_OUTPUT=$output" >> "$GITHUB_ENV"
 echo "DEPLOYMENT_URL=$url" >> "$GITHUB_ENV"

--- a/.github/cloudflare-deploy.sh
+++ b/.github/cloudflare-deploy.sh
@@ -45,5 +45,12 @@ output=$(yarn wrangler pages deploy "$STATICS_DIRECTORY" --project-name "$REPOSI
 output="${output//$'\n'/ }"
 # Extracting URL from output only
 url=$(echo "$output" | grep -o 'https://[^ ]*' | sed 's/ //g')
+
+# debug
+echo "===output==="
+echo $output
+echo "===url==="
+echo $url
+
 echo "DEPLOYMENT_OUTPUT=$output" >> "$GITHUB_ENV"
 echo "DEPLOYMENT_URL=$url" >> "$GITHUB_ENV"


### PR DESCRIPTION
Resolves https://github.com/ubiquity/work.ubq.fi/pull/92#issuecomment-2373829032

In some cases `wrangler` [outputs](https://github.com/ubiquity/cloudflare-deploy-action/blob/22d2f28d7265b389333832c1407174f9bdfebcb0/.github/cloudflare-deploy.sh#L44) multiple URLs:
```
yarn run v1.22.22 $ /home/runner/work/work.ubq.fi/work.ubq.fi/node_modules/.bin/wrangler pages deploy static --project-name work-ubq-fi --branch ubiquity/feat/PWA-App --commit-dirty=true Uploading... (23/26) Uploading... (24/26) Uploading... (25/26) Uploading... (26/26) ✨ Success! Uploaded 3 files (23 already uploaded) (1.97 sec) 🌎 Deploying... ✨ Deployment complete! Take a peek over at https://eab4e290.devpool-directory-ui.pages.dev ✨ Deployment alias URL: https://ubiquity-feat-pwa-app.devpool-directory-ui.pages.dev Done in 8.09s.
```

This PR fetches the 1st URL from wrangler's output.

QA: https://github.com/ubiquity/work.ubq.fi/pull/92#issuecomment-2375217184