### PR TITLE
refactor: check that project exists

### DIFF
--- a/.github/cloudflare-deploy.sh
+++ b/.github/cloudflare-deploy.sh
@@ -15,9 +15,9 @@ echo "Checking if project exists..."
 # Specifically scoped for public contributors to automatically deploy to our team Cloudflare account
 
 # Fetch the list of projects and check if the specific project exists
-project_exists=$(curl -s -X GET "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects" \
+project_exists=$(curl -s -X GET "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$REPOSITORY_NAME" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-  -H "Content-Type: application/json" | jq -r ".result[] | select(.name == \"$REPOSITORY_NAME\") | .name")
+  -H "Content-Type: application/json" | jq -r ".result.name")
 
 if [ "$project_exists" == "$REPOSITORY_NAME" ]; then
   echo "Project already exists. Skipping creation..."


### PR DESCRIPTION
Check [this](https://github.com/ubiquity/pay.ubq.fi/actions/runs/11262899905/job/31319630742) CI run which fails with the `A project with this name already exists. Choose a different project name.`.

[Here](https://github.com/ubiquity/cloudflare-deploy-action/blob/7f547b7178a0a52a1f853d26443c8f8a02438780/.github/cloudflare-deploy.sh#L18) we checked that project exists via this API `GET /accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects` which returns **paginated** projects. In [this](https://github.com/ubiquity/pay.ubq.fi/actions/runs/11262899905/job/31319630742) case `pay-ubq-fi` is no longer on the 1st paganation page hence the script tried to create a new project although it already exists but displayed on page 2.

This PR checks that project exists by using another API `GET /accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT_NAME` which fetches project details directly.