### PR TITLE
fix: update GitHub Actions dependencies to latest official versions

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -8,5 +8,5 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ubiquity/action-conventional-commits@master

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: Get GitHub App token
       if: inputs.app_id != '' && inputs.app_private_key != '' # Only attempt to authenticate if `app_id` and `app_private_key` are provided
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@v2
       id: get_installation_token
       with:
         app-id: ${{ inputs.app_id }}

--- a/action.yml
+++ b/action.yml
@@ -49,11 +49,11 @@ runs:
 
     - name: Get GitHub App token
       if: inputs.app_id != '' && inputs.app_private_key != '' # Only attempt to authenticate if `app_id` and `app_private_key` are provided
-      uses: tibdex/github-app-token@v1.7.0
+      uses: actions/create-github-app-token@v1
       id: get_installation_token
       with:
-        app_id: ${{ inputs.app_id }}
-        private_key: ${{ inputs.app_private_key }}
+        app-id: ${{ inputs.app_id }}
+        private-key: ${{ inputs.app_private_key }}
 
     - name: Find associated pull request
       id: pr
@@ -77,11 +77,11 @@ runs:
           return {forcePreviewDeploy: forcePreviewDeploy, pullRequestNumber: pullRequestNumber }
 
     - name: Download build artifact
-      uses: dawidd6/action-download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.build_artifact_name }}
         path: ${{ inputs.output_directory }}
-        run_id: ${{ inputs.workflow_run_id }}
+        run-id: ${{ inputs.workflow_run_id }}
 
     - name: Deploy to Cloudflare
       run: bash ../../_actions/ubiquity/cloudflare-deploy-action/main/.github/cloudflare-deploy.sh "${{ inputs.repository }}" "${{ inputs.production_branch }}" "${{ inputs.output_directory }}" "${{ fromJSON(steps.pr.outputs.result).forcePreviewDeploy && format('{0}/{1}', github.repository_owner, inputs.current_branch) || inputs.current_branch }}" "${{ inputs.statics_directory }}"


### PR DESCRIPTION
Resolves ubiquity#29

I don't think I can provide a QA before merging it, because there are hardcoded paths to the main branch in the script.

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
